### PR TITLE
Add doctrine/dbal dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php": "^8.0",
         "brick/geo": "~0.8.0 || ~0.9.0",
-        "doctrine/orm": "^2.8"
+        "doctrine/orm": "^2.8",
+        "doctrine/dbal": "^3.3"
     },
     "require-dev": {
         "doctrine/annotations": "^1.0",


### PR DESCRIPTION
I've got an error when trying flush entity to MySQL/MariaDB database with doctrine/dbal:2.13.9.
Set version of DBAL 3.3 because it's minimal for using `AbstractMySQLPlatform` [https://github.com/doctrine/dbal/pull/5098](https://github.com/doctrine/dbal/pull/5098).
This PR might prevents that situations.